### PR TITLE
Open fzf picker under prompt instead of fullscreen

### DIFF
--- a/popman.plugin.zsh
+++ b/popman.plugin.zsh
@@ -39,7 +39,7 @@ popman() {
     choice=$(echo "$cmds" | head -n 1)
   else
     # TODO: This should happen in the tmux popup instead of direcly in the buffer
-    choice=$(echo "$cmds" | fzf --layout=reverse --prompt="Select the tool you need help with: " --print-query | tr -d '\n')
+    choice=$(echo "$cmds" | fzf --height 5 --layout=reverse --prompt="Select the tool you need help with: " --print-query | tr -d '\n')
   fi
   if [ "${TMUX}" ]; then
     tmux popup -EE -h 90% -w 90% man "$choice"


### PR DESCRIPTION
Usually pickers like this opens under prompt. Here is how [fzf-tab](https://github.com/Aloxaf/fzf-tab) and [comma](https://github.com/nix-community/comma) do it: https://asciinema.org/a/671802.

I passed `--height 5` parameter into fzf and now it looks like this: https://asciinema.org/a/671803 (number 5 is in question).

But it's currently clearing the prompt and I don't know how to prevent that.